### PR TITLE
fixes webkit error with 0.xx numbers for offset().left/top (webkit)

### DIFF
--- a/jquery.viewport.js
+++ b/jquery.viewport.js
@@ -14,22 +14,22 @@
 
     $.belowthefold = function(element, settings) {
         var fold = $(window).height() + $(window).scrollTop();
-        return fold <= $(element).offset().top - settings.threshold;
+        return fold <= Math.round($(element).offset().top) - settings.threshold;
     };
 
     $.abovethetop = function(element, settings) {
         var top = $(window).scrollTop();
-        return top >= $(element).offset().top + $(element).height() - settings.threshold;
+        return top >= Math.round($(element).offset().top) + $(element).height() - settings.threshold;
     };
 
     $.rightofscreen = function(element, settings) {
         var fold = $(window).width() + $(window).scrollLeft();
-        return fold <= $(element).offset().left - settings.threshold;
+        return fold <= Math.round($(element).offset().left) - settings.threshold;
     };
 
     $.leftofscreen = function(element, settings) {
         var left = $(window).scrollLeft();
-        return left >= $(element).offset().left + $(element).width() - settings.threshold;
+        return left >= Math.round($(element).offset().left) + $(element).width() - settings.threshold;
     };
 
     $.inviewport = function(element, settings) {
@@ -90,6 +90,4 @@
             return $.inviewport(a, {threshold : 0});
         }
     });
-
-
 })(jQuery);


### PR DESCRIPTION
if you divide a screensize by 3 and use this percentage for the css property left, you don't have a round number. this is what this library requires. by adding a round method this issue is fixed.

Occurs in webkit.
